### PR TITLE
Include import of optional

### DIFF
--- a/api_account.go
+++ b/api_account.go
@@ -17,6 +17,7 @@ import (
 	"net/url"
 	"strings"
 	"fmt"
+	"github.com/antihax/optional"
 )
 
 // Linger please


### PR DESCRIPTION
When trying to use this SDK I get the following error: api_account.go:872:17: undefined: optional

That line is:

    ForgotPassword optional.Interface

Looking at other files (e.g. api_account_recharge), it looks like you use "github.com/antihax/optional" so I added that to the imports.